### PR TITLE
Add multiple API providers for domain search

### DIFF
--- a/src/app/api/domains/check-availability/route.ts
+++ b/src/app/api/domains/check-availability/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import fetch from 'node-fetch';
 
-async function checkDomainAvailability(domain: string): Promise<boolean> {
-  const response = await fetch(`https://api.example.com/check?domain=${domain}`);
+async function checkDomainAvailability(domain: string, providerUrl: string): Promise<boolean> {
+  const response = await fetch(`${providerUrl}?domain=${domain}`);
   if (!response.ok) {
     throw new Error('Failed to fetch domain availability');
   }
@@ -11,9 +11,9 @@ async function checkDomainAvailability(domain: string): Promise<boolean> {
 }
 
 export async function POST(request: Request) {
-  const { domains } = await request.json();
+  const { domains, provider } = await request.json();
 
-  if (!Array.isArray(domains) || domains.length === 0) {
+  if (!Array.isArray(domains) || domains.length === 0 || typeof provider !== 'string') {
     return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
   }
 
@@ -21,7 +21,7 @@ export async function POST(request: Request) {
 
   for (const domain of domains) {
     try {
-      const isAvailable = await checkDomainAvailability(domain);
+      const isAvailable = await checkDomainAvailability(domain, provider);
       results[domain] = isAvailable;
     } catch (error) {
       results[domain] = false;

--- a/src/app/api/domains/providers.ts
+++ b/src/app/api/domains/providers.ts
@@ -1,0 +1,14 @@
+export const apiProviders = [
+  {
+    name: 'Provider 1',
+    url: 'https://api.provider1.com/check?domain=',
+  },
+  {
+    name: 'Provider 2',
+    url: 'https://api.provider2.com/check?domain=',
+  },
+  {
+    name: 'Provider 3',
+    url: 'https://api.provider3.com/check?domain=',
+  },
+];

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,10 +2,12 @@
 
 import React, { useState } from 'react';
 import Button from '../components/Button';
+import { apiProviders } from '../api/domains/providers';
 
 export default function Home() {
   const [searchInput, setSearchInput] = useState('');
   const [searchResults, setSearchResults] = useState<string[]>([]);
+  const [selectedProvider, setSelectedProvider] = useState(apiProviders[0].url);
 
   const handleSearch = async () => {
     try {
@@ -14,7 +16,7 @@ export default function Home() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ domains: [searchInput] }),
+        body: JSON.stringify({ domains: [searchInput], provider: selectedProvider }),
       });
 
       if (!response.ok) {
@@ -42,6 +44,17 @@ export default function Home() {
           placeholder="Enter domain name"
           className="w-full px-3 py-2 border rounded"
         />
+        <select
+          value={selectedProvider}
+          onChange={(e) => setSelectedProvider(e.target.value)}
+          className="w-full px-3 py-2 border rounded"
+        >
+          {apiProviders.map((provider, index) => (
+            <option key={index} value={provider.url}>
+              {provider.name}
+            </option>
+          ))}
+        </select>
         <Button variant="primary" onClick={handleSearch}>Search Domains</Button>
       </div>
       {searchResults.length > 0 && (


### PR DESCRIPTION
Add options for users to select API provider in the domain search form.

* Add a dropdown in `src/app/page.tsx` to select API provider.
* Update the `handleSearch` function in `src/app/page.tsx` to include the selected API provider in the request.
* Modify the `checkDomainAvailability` function in `src/app/api/domains/check-availability/route.ts` to use the selected API provider.
* Update the `POST` function in `src/app/api/domains/check-availability/route.ts` to include the selected API provider in the request.
* Create a new file `src/app/api/domains/providers.ts` to store the list of available API providers and export the list as an array of objects with `name` and `url` properties.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ggindev/domAIn?shareId=dd71c0d4-1353-4530-9f91-2d9625cc7c57).