### PR TITLE
Fix ESLint errors related to unused variables and explicit 'any' types

### DIFF
--- a/src/app/api/domains/check-availability/route.ts
+++ b/src/app/api/domains/check-availability/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
     try {
       const isAvailable = await checkDomainAvailability(domain, provider);
       results[domain] = isAvailable;
-    } catch (error) {
+    } catch {
       results[domain] = false;
     }
   }

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import Button from '../../components/Button';
 
 const ERROR_FETCHING_FAVORITES = 'An error occurred while fetching favorites. Please try again.';
@@ -14,7 +13,6 @@ const FavoritesPage = () => {
   const [page, setPage] = useState(1);
   const [pageSize] = useState(10);
   const [totalFavorites, setTotalFavorites] = useState(0);
-  const router = useRouter();
 
   useEffect(() => {
     const fetchFavorites = () => {

--- a/src/components/DomainGeneratorForm.tsx
+++ b/src/components/DomainGeneratorForm.tsx
@@ -51,7 +51,6 @@ const DomainGeneratorForm: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [availability, setAvailability] = useState<DomainAvailability>({});
-  const [favorites, setFavorites] = useState<string[]>([]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value, type, checked } = e.target;
@@ -125,7 +124,7 @@ const DomainGeneratorForm: React.FC = () => {
 
   const handlePageChange = (newPage: number) => {
     setFormData(prev => ({ ...prev, page: newPage }));
-    handleSubmit(new Event('submit') as any);
+    handleSubmit(new Event('submit') as unknown as React.FormEvent);
   };
 
   const handleFavorite = async (domain: string) => {

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -29,7 +29,7 @@ export default function LoginForm() {
         const data = await response.json();
         setError(data.message || ERROR_LOGIN_FAILED);
       }
-    } catch (err) {
+    } catch {
       setError(ERROR_GENERIC);
     }
   };

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -36,7 +36,7 @@ export default function RegisterForm() {
         const data = await response.json();
         setError(data.message || ERROR_REGISTRATION_FAILED);
       }
-    } catch (err) {
+    } catch {
       setError(ERROR_GENERIC);
     }
   };

--- a/src/services/domainGenerator.ts
+++ b/src/services/domainGenerator.ts
@@ -41,9 +41,7 @@ export async function generateDomains(
   includeNumbers: boolean,
   includeHyphens: boolean,
   page: number = 1,
-  pageSize: number = 10,
-  prefixes: string[] = [],
-  tlds: string[] = []
+  pageSize: number = 10
 ): Promise<DomainInfo[]> {
   const characters = ALPHABET + (includeNumbers ? NUMBERS : '') + (includeHyphens ? '-' : '');
   const totalLength = prefixLength + suffixLength;


### PR DESCRIPTION
Fixes #14

Fix TypeScript ESLint errors related to unused variables and explicit 'any' types.

* **Remove unused variables:**
  - `src/app/api/domains/check-availability/route.ts`: Remove the unused variable `error`.
  - `src/app/favorites/page.tsx`: Remove the unused variable `router`.
  - `src/components/DomainGeneratorForm.tsx`: Remove the unused variable `favorites`.
  - `src/components/LoginForm.tsx`: Remove the unused variable `err`.
  - `src/components/RegisterForm.tsx`: Remove the unused variable `err`.
  - `src/services/domainGenerator.ts`: Remove the unused variables `prefixes` and `tlds`.

* **Replace explicit 'any' type:**
  - `src/components/DomainGeneratorForm.tsx`: Replace `any` with `unknown` and cast to `React.FormEvent` in the `handleSubmit` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ggindev/domAIn/issues/14?shareId=98237fd9-67c1-438d-b231-9d426ba44ac7).